### PR TITLE
Hitting a number higher than the number of tabs open should open the last tab

### DIFF
--- a/src/ctrlnumber.js
+++ b/src/ctrlnumber.js
@@ -1,6 +1,9 @@
 browser.commands.onCommand.addListener(async function(command) {
-    const idx = command.slice(-1) % 9 - 1;
+    let idx = command.slice(-1) % 9 - 1;
     const tabs = await browser.tabs.query({ currentWindow: true, hidden: false});
+    if (tabs.length <= idx) {
+        idx = tabs.length - 1
+    }
     const tab = tabs.slice(idx);
     if (tab.length) {
         browser.tabs.update(tab[0].id, { active: true });


### PR DESCRIPTION
This change fixes issue #2.