### PR TITLE
Update ctrlnumber.js to ignore pinned tabs

### DIFF
--- a/src/ctrlnumber.js
+++ b/src/ctrlnumber.js
@@ -1,6 +1,6 @@
 browser.commands.onCommand.addListener(async function(command) {
     let idx = command.slice(-1) % 9 - 1;
-    const tabs = await browser.tabs.query({ currentWindow: true, hidden: false});
+    const tabs = await browser.tabs.query({ currentWindow: true, hidden: false, pinned: false});
     if (tabs.length <= idx) {
         idx = tabs.length - 1
     }


### PR DESCRIPTION
resolves #5 by ignoring pinned tabs by default
## Project proposal
2023-12-03 @ 18:24 
I want to get better at programming, that means being able to write code that solves problems. Adding to a plugin I use provides;
- a project to work on 
- a motivation to finish that project
- evidence of my work
- value to others

I'm thinking of improving the plugin [firefox-ctrlnumber](https://github.com/AbigailBuccaneer/firefox-ctrlnumber) as its a simple one & I have a very simple idea of how I would improve it.
I would like it to ignore pinned tabs for which I sent a [feature request](https://github.com/AbigailBuccaneer/firefox-ctrlnumber/issues/5) but I would like it give it a go myself.
# Improving [firefox-ctrlnumber](https://github.com/AbigailBuccaneer/firefox-ctrlnumber) 
2023-12-05 @ 16:32 
From my experience most pinned tabs are not used for general browsing and users often already have unique shortcuts for the ones they need this is evidenced by the fact firefoxe's built in ctrl+tab ignores pinned tabs. Therefore ignoring pinned tabs is a sensible default. 
## The code
The main code of the extension is as follows:
``` js
browser.commands.onCommand.addListener(async function(command) {
    let idx = command.slice(-1) % 9 - 1;
    const tabs = await browser.tabs.query({ currentWindow: true, hidden: false});
    if (tabs.length <= idx) {
        idx = tabs.length - 1
    }
    const tab = tabs.slice(idx);
    if (tab.length) {
        browser.tabs.update(tab[0].id, { active: true });
    }
});
```
From initial inspection it would seem all I need to do is add a modifier to the query in line 3,
``` js
browser.tabs.query({ currentWindow: true, hidden: false});
```
The [documentation](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/query) for `tabs.quiery` is very clear and lists one of the optional properties as:
	[`pinned`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/query#pinned) Optional
		`boolean`. Whether the tabs are pinned.
so I add `, pinned: false` like so:
``` js
browser.tabs.query({ currentWindow: true, hidden: false, pinned: false});
```
I assume it handles multiple `queryObj` as `&&` as there already seems to be 2 in there separated by commas working just fine.
The full `src/ctrlnumber.js` would then be:
``` js
browser.commands.onCommand.addListener(async function(command) {
    let idx = command.slice(-1) % 9 - 1;
    const tabs = await browser.tabs.query({ currentWindow: true, hidden: false});
    if (tabs.length <= idx) {
        idx = tabs.length - 1
    }
    const tab = tabs.slice(idx);
    if (tab.length) {
        browser.tabs.update(tab[0].id, { active: true });
    }
});
```
The next step is to figure out how to test & apply my solution...
## Implementation
2023-12-05 @ 16:43 
I have Mozilla's documentation very clear and helpful and very quickly found a [page explaining how to implement your own extensions](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_first_WebExtension#trying_it_out).
1. open about:debugging#/runtime/this-firefox 
2. click "load temporary Add-on..."
The extension will be installed & enabled until you restart Firefox.

I cloned the Git repo & made the previously described amendment, added it as a temporary add-on and it worked as expected.
## Further improvement's
2023-12-06 @ 04:20 
From here a basic preferences page could be added allowing users to change which tabs are ignored.